### PR TITLE
fix: prevent scrollbar glitch on footer image animation

### DIFF
--- a/src/app/Utilities/footer/footer.component.html
+++ b/src/app/Utilities/footer/footer.component.html
@@ -2,11 +2,11 @@
     <div class="container-fluid">
         <div class="row">
             <div class="col-md-4 p1">
-                <div class="text-center rotate">
-                    <img src="../../../assets/images/Swasthify-logo-black.png" height="100 " width="100 " />
+                <div class="text-center">
+                    <img class="rotate" src="../../../assets/images/Swasthify-logo-black.png" height="100" width="100" />
                 </div>
                 <br />
-                <h1 class="swasthify grow text-center">SWASTHIFY</h1>
+                <h1 routerLink="/home" class="swasthify grow text-center">SWASTHIFY</h1>
             </div>
             <div class="col-md-4 p1">
                 <h3 style="text-align: center; color: white">CONNECT WITH US</h3>

--- a/src/app/Utilities/footer/footer.component.scss
+++ b/src/app/Utilities/footer/footer.component.scss
@@ -22,6 +22,7 @@
      text-align: center;
      color: #d5d5d5;
      font-size: 13px;
+     cursor: pointer;
  }
  
  .swasthify:hover {


### PR DESCRIPTION
Issue reference / resolves - #64 

[FIXES]
* Moved the `rotate` animation to the image to prevent scrollbar glitch

[CHORES]
* Add 'home' link to footer heading when clicked